### PR TITLE
Cast to `*mut u8` early to avoid `align_offset` failure

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -117,6 +117,16 @@ mod not_aligned_enough {
     fn test4() {
         TaggedPtr::<_, 4>::new((&Align8(0)).into(), 0);
     }
+
+    #[test]
+    #[should_panic]
+    fn test5() {
+        let ptr: *mut Align2 = &mut Align2(0);
+        let ptr = unsafe { (ptr as *mut u8).add(1) };
+        let ptr = ptr as *mut Align2;
+        let ptr = unsafe { NonNull::new_unchecked(ptr) };
+        TaggedPtr::<_, 1>::new(ptr, 0);
+    }
 }
 
 #[cfg(not(feature = "fallback"))]


### PR DESCRIPTION
Thanks for the awesome crate! I'm playing around with adding a `TaggedRef` and `TaggedMutRef`, for which I'll create a separate PR. In the meantime I found this issue, which is rather minor but causes less precise error reporting (alternatively an `assert` which will always succeed).

The documentation of `align_offset` states that "The offset is expressed in number of `T` elements, and not bytes. The value returned can be used with the `wrapping_add` method". Therefore, in `new` by calling this function with a `ptr: *mut T` which was already unaligned would cause the `usize::MAX` failure return, rather than giving a non-zero `offset`. Since calling `align_offset::<T>(N)` where `mem::align_of::<T>() >= N` (as is true in `new`) can only ever return `0` or `usize::MAX`, the `assert!(offset & mask(BITS) == 0)` would never fail.