### PR TITLE
Switch to performing some checks at compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ categories = ["data-structures", "no-std"]
 
 [features]
 fallback = []
+
+[dev-dependencies]
+compiletest_rs = "0.10"

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -16,21 +16,25 @@
  * limitations under the License.
  */
 
-use super::mask;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::ptr::NonNull;
 
-pub struct PtrImpl<T, const BITS: usize> {
+pub struct PtrImpl<T, const BITS: u32> {
     ptr: NonNull<T>,
     tag: usize,
 }
 
-impl<T, const BITS: usize> PtrImpl<T, BITS> {
+impl<T, const BITS: u32> PtrImpl<T, BITS> {
     pub fn new(ptr: NonNull<T>, tag: usize) -> Self {
+        // Even though these checks are not necessary here, we want to ensure
+        // that if the fallback compiles then so would the default.
+        let _ = Self::T_ALIGNED_PO2;
+        let _ = Self::T_SIZE_GE_ALIGNMENT;
+        let _ = Self::ENOUGH_ALIGNMENT_BITS;
         Self {
             ptr,
-            tag: tag & mask(BITS),
+            tag: tag & Self::MASK,
         }
     }
 
@@ -39,7 +43,7 @@ impl<T, const BITS: usize> PtrImpl<T, BITS> {
     }
 }
 
-impl<T, const BITS: usize> Clone for PtrImpl<T, BITS> {
+impl<T, const BITS: u32> Clone for PtrImpl<T, BITS> {
     fn clone(&self) -> Self {
         Self {
             ptr: self.ptr,
@@ -48,19 +52,19 @@ impl<T, const BITS: usize> Clone for PtrImpl<T, BITS> {
     }
 }
 
-impl<T, const BITS: usize> PartialEq for PtrImpl<T, BITS> {
+impl<T, const BITS: u32> PartialEq for PtrImpl<T, BITS> {
     fn eq(&self, other: &Self) -> bool {
         (self.ptr, self.tag) == (other.ptr, other.tag)
     }
 }
 
-impl<T, const BITS: usize> Ord for PtrImpl<T, BITS> {
+impl<T, const BITS: u32> Ord for PtrImpl<T, BITS> {
     fn cmp(&self, other: &Self) -> Ordering {
         (self.ptr, self.tag).cmp(&(other.ptr, other.tag))
     }
 }
 
-impl<T, const BITS: usize> Hash for PtrImpl<T, BITS> {
+impl<T, const BITS: u32> Hash for PtrImpl<T, BITS> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (self.ptr, self.tag).hash(state);
     }

--- a/src/messages/align-offset-failed
+++ b/src/messages/align-offset-failed
@@ -3,7 +3,7 @@ reasons (most likely one of the first two):
 
 * The pointer passed to `TaggedPtr::new` wasn't aligned enough.
 
-* The pointer passed to `TaggedPtr::new` wasn't "dereferencable" in
+* The pointer passed to `TaggedPtr::new` wasn't "dereferenceable" in
   the sense defined by the documentation for `std::ptr`.
 
 * The current implementation of `align_offset` sometimes or always

--- a/src/messages/wrapped-to-null
+++ b/src/messages/wrapped-to-null
@@ -1,2 +1,2 @@
 `ptr` became null after adding `tag`. This shouldn't happen if `ptr` is
-"dereferencable" in the sense defined by `std::ptr`.
+"dereferenceable" in the sense defined by `std::ptr`.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -117,6 +117,16 @@ mod not_aligned_enough {
     fn test4() {
         TaggedPtr::<_, 4>::new((&Align8(0)).into(), 0);
     }
+
+    #[test]
+    #[should_panic]
+    fn test5() {
+        let ptr: *mut Align2 = &mut Align2(0);
+        let ptr = unsafe { (ptr as *mut u8).add(1) };
+        let ptr = ptr as *mut Align2;
+        let ptr = unsafe { NonNull::new_unchecked(ptr) };
+        TaggedPtr::<_, 1>::new(ptr, 0);
+    }
 }
 
 #[cfg(not(feature = "fallback"))]

--- a/src/tests_compile_fail/align1.rs
+++ b/src/tests_compile_fail/align1.rs
@@ -1,0 +1,9 @@
+//@ error-pattern:alignment of `T` must be greater or equal to `BITS`
+
+// If the test fails here with E0464, run `cargo clean` and try again.
+extern crate tagged_pointer;
+use tagged_pointer::TaggedPtr;
+
+fn main() {
+    TaggedPtr::<_, 1>::new((&0_u8).into(), 0);
+}

--- a/src/tests_compile_fail/align2.rs
+++ b/src/tests_compile_fail/align2.rs
@@ -1,0 +1,13 @@
+//@ error-pattern:alignment of `T` must be greater or equal to `BITS`
+
+// If the test fails here with E0464, run `cargo clean` and try again.
+extern crate tagged_pointer;
+use tagged_pointer::TaggedPtr;
+
+#[repr(align(2))]
+#[derive(Debug, Eq, PartialEq)]
+struct Align2(pub u16);
+
+fn main() {
+    TaggedPtr::<_, 2>::new((&Align2(0)).into(), 0);
+}

--- a/src/tests_compile_fail/align4.rs
+++ b/src/tests_compile_fail/align4.rs
@@ -1,0 +1,13 @@
+//@ error-pattern:alignment of `T` must be greater or equal to `BITS`
+
+// If the test fails here with E0464, run `cargo clean` and try again.
+extern crate tagged_pointer;
+use tagged_pointer::TaggedPtr;
+
+#[repr(align(4))]
+#[derive(Debug, Eq, PartialEq)]
+struct Align4(pub u32);
+
+fn main() {
+    TaggedPtr::<_, 3>::new((&Align4(0)).into(), 0);
+}

--- a/src/tests_compile_fail/align8.rs
+++ b/src/tests_compile_fail/align8.rs
@@ -1,0 +1,13 @@
+//@ error-pattern:alignment of `T` must be greater or equal to `BITS`
+
+// If the test fails here with E0464, run `cargo clean` and try again.
+extern crate tagged_pointer;
+use tagged_pointer::TaggedPtr;
+
+#[repr(align(8))]
+#[derive(Debug, Eq, PartialEq)]
+struct Align8(pub u64);
+
+fn main() {
+    TaggedPtr::<_, 4>::new((&Align8(0)).into(), 0);
+}


### PR DESCRIPTION
This PR builds on https://github.com/taylordotfish/tagged-pointer/pull/1 and introduces three main changes:

1. Switch `BITS` from `usize` to `u32`, this matches `std`'s [assumption](https://doc.rust-lang.org/std/primitive.usize.html#associatedconstant.BITS) that the bit width of pointers (`usize`) will not exceed 2^23. This originates from LLVM [here](https://llvm.org/docs/LangRef.html#integer-type).
2. Ensure that `mask` and `alignment` are calculated at compile-time by making them an associated constant.
3. Make use of https://github.com/rust-lang/rfcs/pull/2345 to check the basic alignment vs requested `BITS` properties at compile time.

Some design decisions:

- Since the checks from 3. are required to ensure SAFETY (maybe not for the lib, but definitely for the client) I have moved them into `PtrImpl` (with minimal duplication in `fallback`)
- I have kept these checks enabled in `fallback` since users will want to be able to switch between the two without running into compilation errors.
- I have kept the "However, if its alignment is not at least 2<sup>`BITS`</sup>, this function may panic" behavior **disabled** for `fallback`, one may want to actually enable the panic here for the same reason as above.
- Testing of 3. is no longer so easy - there is no `should_panic` equivalent for `shouldnt_compile`. I opted to use `compiletest_rs` which is commonly used in such situations. Unfortunately it comes with a few issues since one needs to manually link in the `tagged_pointer.rlib` to the compile-fail tests.
Due to the dependency on `compiletest_rs` and this issue, `std` is enabled for `cargo test` (only).