### PR TITLE
Add support for tagged references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tagged-pointer"
-version = "0.2.7-dev"
+version = "0.3.0-dev"
 edition = "2018"
 rust-version = "1.51"
 description = "Platform-independent space-efficient tagged pointers"

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 taylor.fish <contact@taylor.fish>
+ * Copyright 2021-2024 taylor.fish <contact@taylor.fish>
  *
  * This file is part of tagged-pointer.
  *
@@ -16,42 +16,37 @@
  * limitations under the License.
  */
 
-use super::Bits;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::ptr::NonNull;
 
-pub(crate) struct PtrImpl<T, const BITS: Bits> {
+pub struct PtrImpl<T> {
     ptr: NonNull<T>,
     tag: usize,
 }
 
-impl<T, const BITS: Bits> PtrImpl<T, BITS> {
-    pub(crate) fn new(ptr: NonNull<T>, tag: usize) -> Self {
-        // Ensure compile-time checks are evaluated. Even though the checks
-        // are not strictly necessary for the fallback implementation, it's
-        // desirable to match the behavior of the standard implementation.
-        Self::assert();
+impl<T> PtrImpl<T> {
+    pub fn new(ptr: NonNull<T>, tag: usize) -> Self {
         Self {
             ptr,
             tag: tag & Self::MASK,
         }
     }
 
-    pub(crate) unsafe fn new_unchecked(ptr: NonNull<T>, tag: usize) -> Self {
+    pub unsafe fn new_unchecked(ptr: NonNull<T>, tag: usize) -> Self {
         Self::new(ptr, tag)
     }
 
-    pub(crate) fn get(self) -> (NonNull<T>, usize) {
+    pub fn get(self) -> (NonNull<T>, usize) {
         (self.ptr, self.tag)
     }
 
-    pub(crate) unsafe fn get_unchecked(self) -> (NonNull<T>, usize) {
+    pub unsafe fn get_unchecked(self) -> (NonNull<T>, usize) {
         self.get()
     }
 }
 
-impl<T, const BITS: Bits> Clone for PtrImpl<T, BITS> {
+impl<T> Clone for PtrImpl<T> {
     fn clone(&self) -> Self {
         Self {
             ptr: self.ptr,
@@ -60,19 +55,19 @@ impl<T, const BITS: Bits> Clone for PtrImpl<T, BITS> {
     }
 }
 
-impl<T, const BITS: Bits> PartialEq for PtrImpl<T, BITS> {
+impl<T> PartialEq for PtrImpl<T> {
     fn eq(&self, other: &Self) -> bool {
         (self.ptr, self.tag) == (other.ptr, other.tag)
     }
 }
 
-impl<T, const BITS: Bits> Ord for PtrImpl<T, BITS> {
+impl<T> Ord for PtrImpl<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         (self.ptr, self.tag).cmp(&(other.ptr, other.tag))
     }
 }
 
-impl<T, const BITS: Bits> Hash for PtrImpl<T, BITS> {
+impl<T> Hash for PtrImpl<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (self.ptr, self.tag).hash(state);
     }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 taylor.fish <contact@taylor.fish>
+ * Copyright 2021-2023 taylor.fish <contact@taylor.fish>
  *
  * This file is part of tagged-pointer.
  *
@@ -21,13 +21,13 @@ use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::ptr::NonNull;
 
-pub struct PtrImpl<T, const BITS: Bits> {
+pub(crate) struct PtrImpl<T, const BITS: Bits> {
     ptr: NonNull<T>,
     tag: usize,
 }
 
 impl<T, const BITS: Bits> PtrImpl<T, BITS> {
-    pub fn new(ptr: NonNull<T>, tag: usize) -> Self {
+    pub(crate) fn new(ptr: NonNull<T>, tag: usize) -> Self {
         // Ensure compile-time checks are evaluated. Even though the checks
         // are not strictly necessary for the fallback implementation, it's
         // desirable to match the behavior of the standard implementation.
@@ -38,8 +38,16 @@ impl<T, const BITS: Bits> PtrImpl<T, BITS> {
         }
     }
 
-    pub fn get(self) -> (NonNull<T>, usize) {
+    pub(crate) unsafe fn new_unchecked(ptr: NonNull<T>, tag: usize) -> Self {
+        Self::new(ptr, tag)
+    }
+
+    pub(crate) fn get(self) -> (NonNull<T>, usize) {
         (self.ptr, self.tag)
+    }
+
+    pub(crate) unsafe fn get_unchecked(self) -> (NonNull<T>, usize) {
+        self.get()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 taylor.fish <contact@taylor.fish>
+ * Copyright 2021-2024 taylor.fish <contact@taylor.fish>
  *
  * This file is part of tagged-pointer.
  *
@@ -125,19 +125,37 @@ pub use r#ref::{TaggedMutRef, TaggedRef};
 #[cfg(any(test, doctest))]
 mod tests;
 
-/// [`u32`] might make more sense here (see, e.g., [`u32::BITS`]), but this
-/// would be a breaking change.
-type Bits = usize;
+/// see, e.g., [`u32::BITS`].
+type Bits = u32;
 
-impl<T, const BITS: Bits> PtrImpl<T, BITS> {
+struct Check<T, const BITS: Bits>(T);
+impl<T, const BITS: Bits> Check<T, BITS> {
     #[allow(clippy::no_effect)]
-    /// Compile-time checks. [`Self::new`] calls [`Self::assert`], which forces
+    /// Compile-time checks. [`Self::new`] calls [`Self::ASSERT`], which forces
     /// the checks to be evaluated.
-    const ASSERT: bool = {
-        // `BITS` must at least fit in a `u32` (in reality, it must be much
-        // smaller).
-        let b = BITS <= u32::MAX as Bits;
-        ["`BITS` cannot exceed `u32::MAX`"][!b as usize];
+    const ASSERT: () = {
+        // The `BITS` constant was correctly provided to `new`.
+        let b = BITS == Self::BITS;
+        match Self::BITS {
+            0 => ["`BITS` must be equal to 0"][!b as usize],
+            1 => ["`BITS` must be equal to 1"][!b as usize],
+            2 => ["`BITS` must be equal to 2"][!b as usize],
+            3 => ["`BITS` must be equal to 3"][!b as usize],
+            4 => ["`BITS` must be equal to 4"][!b as usize],
+            5 => ["`BITS` must be equal to 5"][!b as usize],
+            6 => ["`BITS` must be equal to 6"][!b as usize],
+            7 => ["`BITS` must be equal to 7"][!b as usize],
+            8 => ["`BITS` must be equal to 8"][!b as usize],
+            9 => ["`BITS` must be equal to 9"][!b as usize],
+            10 => ["`BITS` must be equal to 10"][!b as usize],
+            11 => ["`BITS` must be equal to 11"][!b as usize],
+            12 => ["`BITS` must be equal to 12"][!b as usize],
+            13 => ["`BITS` must be equal to 13"][!b as usize],
+            14 => ["`BITS` must be equal to 14"][!b as usize],
+            15 => ["`BITS` must be equal to 15"][!b as usize],
+            16 => ["`BITS` must be equal to 16"][!b as usize],
+            _ => ["`BITS` must be equal to `mem::align_of::<T>().trailing_zeros()`"][!b as usize],
+        };
 
         // Assumption about the alignment of `T`. This should always succeed.
         let b = mem::align_of::<T>().is_power_of_two();
@@ -155,30 +173,25 @@ impl<T, const BITS: Bits> PtrImpl<T, BITS> {
         ["expected size of `T` to be multiple of alignment"][!b as usize];
 
         // Ensure `1 << BITS` doesn't overflow.
-        let b = 1_usize.checked_shl(Self::BITS32).is_some();
+        let b = 1_usize.checked_shl(Self::BITS).is_some();
         ["`1 << BITS` doesn't fit in a `usize`"][!b as usize];
 
-        // Ensure `T` is aligned enough to store `BITS` bits.
-        let b = mem::align_of::<T>().trailing_zeros() >= Self::BITS32;
+        // Ensure `T` is aligned enough to store `BITS` bits. This will always
+        // succeed, but is kept around in case `PtrImpl::<T>::BITS` changes.
+        let b = mem::align_of::<T>().trailing_zeros() >= Self::BITS;
         ["alignment of `T` must be at least `1 << BITS`"][!b as usize];
-        true
     };
 
-    fn assert() {
-        // This assertion won't ever actually fail; rather, if any of the
-        // checks in `Self::ASSERT` failed, it will prompt a compiler error.
-        assert!(Self::ASSERT, "compile-time checks failed");
-    }
+    const BITS: u32 = PtrImpl::<T>::BITS;
+}
 
-    #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::unnecessary_cast)]
-    /// `BITS` cast to a `u32`. We ensured this doesn't overflow earlier.
-    const BITS32: u32 = BITS as u32;
+impl<T> PtrImpl<T> {
+    const BITS: u32 = mem::align_of::<T>().trailing_zeros();
 
     /// The alignment required to store `BITS` tag bits. We ensured this
     /// doesn't overflow earlier, so use `wrapping_shl` so that we get only
     /// one compiler error.
-    const ALIGNMENT: usize = 1_usize.wrapping_shl(Self::BITS32);
+    const ALIGNMENT: usize = 1_usize.wrapping_shl(Self::BITS);
 
     /// The bitmask that should be applied to the tag to ensure that it is
     /// smaller than [`Self::ALIGNMENT`]. Since the alignment is always a power
@@ -186,11 +199,11 @@ impl<T, const BITS: Bits> PtrImpl<T, BITS> {
     const MASK: usize = Self::ALIGNMENT - 1;
 }
 
-impl<T, const BITS: Bits> Copy for PtrImpl<T, BITS> {}
+impl<T> Copy for PtrImpl<T> {}
 
-impl<T, const BITS: Bits> Eq for PtrImpl<T, BITS> {}
+impl<T> Eq for PtrImpl<T> {}
 
-impl<T, const BITS: Bits> PartialOrd for PtrImpl<T, BITS> {
+impl<T> PartialOrd for PtrImpl<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
@@ -206,17 +219,19 @@ impl<T, const BITS: Bits> PartialOrd for PtrImpl<T, BITS> {
 /// The tagged pointer conceptually holds a [`NonNull<T>`](NonNull) and a
 /// certain number of bits of an integer tag.
 ///
-/// `BITS` specifies how many bits are used for the tag. The alignment of `T`
-/// must be large enough to store this many bits; see [`Self::new`].
+/// The number of bits that can be stored in the tag is determined as
+/// `mem::align_of::<T>().trailing_zeros()`, any higher bits in the tag will
+/// be masked away. See [`Self::new`] for more details.
 #[repr(transparent)]
-pub struct TaggedPtr<T, const BITS: Bits>(PtrImpl<T, BITS>);
+pub struct TaggedPtr<T>(PtrImpl<T>);
 
-impl<T, const BITS: Bits> TaggedPtr<T, BITS> {
+impl<T> TaggedPtr<T> {
     /// Creates a new tagged pointer. Only the lower `BITS` bits of `tag` are
     /// stored.
     ///
     /// A check is performed at compile time to ensure that the alignment of
-    /// `T` is not less than 2<sup>`BITS`</sup> (`1 << BITS`). This ensures
+    /// `T` is exactly 2<sup>`BITS`</sup> (i.e. that `BITS ==
+    /// mem::align_of::<T>().trailing_zeros()`). This ensures
     /// that all properly aligned pointers to `T` will be aligned enough to
     /// store the specified number of bits of the tag.
     ///
@@ -233,14 +248,28 @@ impl<T, const BITS: Bits> TaggedPtr<T, BITS> {
     ///
     /// [^1]: It is permissible for only the first 2<sup>`BITS`</sup> bytes of
     /// `ptr` to be dereferenceable.
-    pub fn new(ptr: NonNull<T>, tag: usize) -> Self {
+    pub fn new<const BITS: Bits>(ptr: NonNull<T>, tag: usize) -> Self {
+        // Perform compile-time checks as close to call site so that
+        // diagnostics point to user code.
+        let _ = Check::<T, BITS>::ASSERT;
+        Self::new_implied(ptr, tag)
+    }
+
+    /// Creates a new tagged pointer. Identical to [`Self::new`] but without
+    /// needing to explicitly specify the expected number of available bits.
+    /// The number of bits is determined as `mem::align_of::<T>().trailing_zeros()`.
+    /// 
+    /// Using this method is generally not recommended since the tag may be
+    /// unexpectedly truncated if the alignment of `T` is not what you expect.
+    pub fn new_implied(ptr: NonNull<T>, tag: usize) -> Self {
         Self(PtrImpl::new(ptr, tag))
     }
 
     /// Creates a new tagged pointer.
     ///
     /// A check is performed at compile time to ensure that the alignment of
-    /// `T` is not less than 2<sup>`BITS`</sup> (`1 << BITS`). This ensures
+    /// `T` is exactly 2<sup>`BITS`</sup> (i.e. that `BITS ==
+    /// mem::align_of::<T>().trailing_zeros()`). This ensures
     /// that all properly aligned pointers to `T` will be aligned enough to
     /// store the specified number of bits of the tag.
     ///
@@ -249,7 +278,20 @@ impl<T, const BITS: Bits> TaggedPtr<T, BITS> {
     /// `ptr` must be properly aligned.
     ///
     /// `tag` must not be larger than [`Self::mask`].
-    pub unsafe fn new_unchecked(ptr: NonNull<T>, tag: usize) -> Self {
+    pub unsafe fn new_unchecked<const BITS: Bits>(ptr: NonNull<T>, tag: usize) -> Self {
+        // Perform compile-time checks as close to call site so that
+        // diagnostics point to user code.
+        let _ = Check::<T, BITS>::ASSERT;
+        unsafe { Self::new_implied_unchecked(ptr, tag) }
+    }
+
+    /// Creates a new tagged pointer. Identical to [`Self::new_unchecked`] but without
+    /// needing to explicitly specify the expected number of available bits.
+    /// The number of bits is determined as `mem::align_of::<T>().trailing_zeros()`.
+    /// 
+    /// Using this method is generally not recommended since the tag may be
+    /// unexpectedly truncated if the alignment of `T` is not what you expect.
+    pub unsafe fn new_implied_unchecked(ptr: NonNull<T>, tag: usize) -> Self {
         Self(unsafe { PtrImpl::new_unchecked(ptr, tag) })
     }
 
@@ -296,9 +338,9 @@ impl<T, const BITS: Bits> TaggedPtr<T, BITS> {
     /// ```
     /// # use {core::ptr::NonNull, tagged_pointer::TaggedPtr};
     /// # trait Ext<T> { fn set_ptr(&mut self, ptr: NonNull<T>); }
-    /// # impl<T, const BITS: usize> Ext<T> for TaggedPtr<T, BITS> {
+    /// # impl<T> Ext<T> for TaggedPtr<T> {
     /// # fn set_ptr(&mut self, ptr: NonNull<T>) {
-    /// *self = Self::new(ptr, self.tag());
+    /// *self = Self::new_implied(ptr, self.tag());
     /// # }}
     /// ```
     ///
@@ -306,7 +348,7 @@ impl<T, const BITS: Bits> TaggedPtr<T, BITS> {
     ///
     /// See [`Self::new`].
     pub fn set_ptr(&mut self, ptr: NonNull<T>) {
-        *self = Self::new(ptr, self.tag());
+        *self = Self::new_implied(ptr, self.tag());
     }
 
     /// Gets the tag stored by the tagged pointer. Equivalent to
@@ -326,63 +368,66 @@ impl<T, const BITS: Bits> TaggedPtr<T, BITS> {
     ///
     /// ```
     /// # use tagged_pointer::TaggedPtr;
-    /// # trait Ext { fn set_tag(&mut self, tag: usize); }
-    /// # impl<T, const BITS: usize> Ext for TaggedPtr<T, BITS> {
-    /// # fn set_tag(&mut self, tag: usize) {
-    /// *self = Self::new(self.ptr(), tag);
+    /// # trait Ext { fn set_tag<const BITS: u32>(&mut self, tag: usize); }
+    /// # impl<T> Ext for TaggedPtr<T> {
+    /// # fn set_tag<const BITS: u32>(&mut self, tag: usize) {
+    /// *self = Self::new::<BITS>(self.ptr(), tag);
     /// # }}
     /// ```
     ///
     /// # Panics
     ///
     /// See [`Self::new`].
-    pub fn set_tag(&mut self, tag: usize) {
-        *self = Self::new(self.ptr(), tag);
+    pub fn set_tag<const BITS: Bits>(&mut self, tag: usize) {
+        // Perform compile-time checks as close to call site so that
+        // diagnostics point to user code.
+        let _ = Check::<T, BITS>::ASSERT;
+        *self = Self::new_implied(self.ptr(), tag);
     }
 
     /// Returns the bitmask for the tag, use `tag & TaggedPtr::mask()` to
     /// ensure safety of [`Self::new_unchecked`]. Calculated as
     /// 2<sup>`BITS`</sup> - 1.
     pub const fn mask() -> usize {
-        PtrImpl::<T, BITS>::MASK
+        PtrImpl::<T>::MASK
     }
 }
 
-impl<T, const BITS: Bits> Clone for TaggedPtr<T, BITS> {
+impl<T> Clone for TaggedPtr<T> {
     fn clone(&self) -> Self {
         Self(self.0)
     }
 }
 
-impl<T, const BITS: Bits> Copy for TaggedPtr<T, BITS> {}
+impl<T> Copy for TaggedPtr<T> {}
 
-impl<T, const BITS: Bits> PartialEq for TaggedPtr<T, BITS> {
+impl<T> PartialEq for TaggedPtr<T> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
 
-impl<T, const BITS: Bits> Eq for TaggedPtr<T, BITS> {}
+impl<T> Eq for TaggedPtr<T> {}
 
-impl<T, const BITS: Bits> PartialOrd for TaggedPtr<T, BITS> {
+impl<T> PartialOrd for TaggedPtr<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<T, const BITS: Bits> Ord for TaggedPtr<T, BITS> {
+impl<T> Ord for TaggedPtr<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.0.cmp(&other.0)
     }
 }
 
-impl<T, const BITS: Bits> Hash for TaggedPtr<T, BITS> {
+impl<T> Hash for TaggedPtr<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.hash(state);
     }
 }
 
-impl<T, const BITS: Bits> fmt::Debug for TaggedPtr<T, BITS> {
+impl<T> fmt::Debug for TaggedPtr<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (ptr, tag) = self.get();
         f.debug_struct("TaggedPtr")

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -179,7 +179,10 @@ impl<'a, T> TaggedRef<'a, T> {
     /// # }}
     /// ```
     pub fn set_tag<const BITS: Bits>(&mut self, tag: usize) {
-        *self = Self::new::<BITS>(self.reference(), tag);
+        // Perform compile-time checks as close to call site so that
+        // diagnostics point to user code.
+        let _ = Check::<T, BITS>::ASSERT;
+        *self = Self::new_implied(self.reference(), tag);
     }
 }
 
@@ -425,6 +428,9 @@ impl<'a, T> TaggedMutRef<'a, T> {
     /// tr = TaggedMutRef::new::<2>(tr.reference_inner(), 1);
     /// ```
     pub fn set_tag<const BITS: Bits>(&mut self, tag: usize) {
+        // Perform compile-time checks as close to call site so that
+        // diagnostics point to user code.
+        let _ = Check::<T, BITS>::ASSERT;
         let mut ptr = NonNull::from(self.reference_mut());
         // SAFETY: We can extend the lifetime to `'a` since we know that this
         // is the true lifetime of the reference `self` holds. We temporarily
@@ -433,7 +439,7 @@ impl<'a, T> TaggedMutRef<'a, T> {
         // then `self` would not get overwritten, luckily this would still be
         // ok because `reference` is immediately discarded on return.
         let reference = unsafe { ptr.as_mut() };
-        *self = Self::new::<BITS>(reference, tag);
+        *self = Self::new_implied(reference, tag);
     }
 
     /// Creates a new identical tagged reference. Useful to mimic the reborrow

--- a/src/ref.rs
+++ b/src/ref.rs
@@ -1,0 +1,454 @@
+/*
+ * Copyright 2023 Jonáš Fiala <jonas.fiala@inf.ethz.ch>
+ * Copyright 2023 taylor.fish <contact@taylor.fish>
+ *
+ * This file is part of tagged-pointer.
+ *
+ * tagged-pointer is licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use tagged-pointer except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use core::borrow::{Borrow, BorrowMut};
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
+use core::ptr::NonNull;
+
+use super::{Bits, TaggedPtr};
+
+/// A tagged immutable reference: a space-efficient representation of a
+/// reference and integer tag.
+///
+/// This type stores a shared reference and an integer tag without taking up
+/// more space than a normal reference (unless the fallback implementation is
+/// used; see the [crate documentation](crate#assumptions)).
+///
+/// The tagged reference conceptually holds a `&'a T` and a certain number of
+/// bits of an integer tag.
+///
+/// `BITS` specifies how many bits are used for the tag. The alignment of `T`
+/// must be large enough to store this many bits; see [`Self::new`].
+#[repr(transparent)]
+pub struct TaggedRef<'a, T, const BITS: Bits>(
+    TaggedPtr<T, BITS>,
+    PhantomData<&'a T>,
+);
+
+impl<'a, T, const BITS: Bits> TaggedRef<'a, T, BITS> {
+    /// Creates a new tagged pointer. Only the lower `BITS` bits of `tag` are
+    /// stored.
+    ///
+    /// A check is performed at compile time to ensure that the alignment of
+    /// `T` is not less than 2<sup>`BITS`</sup> (`1 << BITS`). This ensures
+    /// that all properly aligned pointers to `T` will be aligned enough to
+    /// store the specified number of bits of the tag.
+    pub fn new(reference: &'a T, tag: usize) -> Self {
+        let ptr = NonNull::from(reference);
+        let tag = tag & TaggedPtr::<T, BITS>::mask();
+        // SAFETY: `reference` is guaranteed to be aligned and `tag <= mask()`.
+        let ptr = unsafe { TaggedPtr::new_unchecked(ptr, tag) };
+        Self(ptr, PhantomData)
+    }
+
+    /// Gets the pointer and tag stored by the tagged pointer.
+    pub fn get(self) -> (&'a T, usize) {
+        // SAFETY: can only have been constructed with `TaggedRef::new`.
+        // Thus `ptr` will be properly aligned and “dereferenceable”.
+        let (ptr, tag) = unsafe { self.0.get_unchecked() };
+        // SAFETY: `ptr` is properly aligned and “dereferenceable”. The
+        // underlying data is initialized and immutable since we hold a shared
+        // reference to `self` which has a `PhantomData<&'a T>`. We respect
+        // Rust lifetimes by returning a copy of the original reference.
+        let ptr = unsafe { ptr.as_ref() };
+        (ptr, tag)
+    }
+
+    /// Gets the reference stored by the tagged reference, without the tag.
+    /// Equivalent to [`self.get().0`](Self::get).
+    pub fn reference(self) -> &'a T {
+        self.get().0
+    }
+
+    /// Sets the reference without modifying the tag.
+    ///
+    /// This method is simply equivalent to:
+    ///
+    /// ```
+    /// # use tagged_pointer::TaggedRef;
+    /// # trait Ext<'a, T> { fn set_reference(&mut self, reference: &'a T); }
+    /// # impl<'a, T, const BITS: usize> Ext<'a, T>
+    /// #    for TaggedRef<'a, T, BITS> {
+    /// # fn set_reference(&mut self, reference: &'a T) {
+    /// *self = Self::new(reference, self.tag());
+    /// # }}
+    /// ```
+    ///
+    /// Note that this method does not kill the original borrow, so the
+    /// following will not compile:
+    ///
+    /// ```compile_fail
+    /// # use tagged_pointer::TaggedRef;
+    /// let (mut x, y) = (14_u32, 21_u32);
+    /// let mut tr = TaggedRef::<_, 2>::new(&x, 0);
+    /// tr.set_reference(&y); // `x` stays borrowed
+    /// x += 1; // use of borrowed `x`
+    /// let v = *tr;
+    /// ```
+    ///
+    /// If you run into this issue, use [`Self::new_reference`] instead.
+    pub fn set_reference(&mut self, reference: &'a T) {
+        *self = Self::new(reference, self.tag());
+    }
+
+    /// Creates a new tagged reference with the same tag.
+    ///
+    /// This method is simply equivalent to:
+    ///
+    /// ```
+    /// # use tagged_pointer::TaggedRef;
+    /// # trait Ext<T, const BITS: usize> { fn set_reference<'b>
+    /// #    (&mut self, reference: &'b T) -> TaggedRef<'b, T, BITS>; }
+    /// # impl<'a, T, const BITS: usize> Ext<T, BITS>
+    /// #    for TaggedRef<'a, T, BITS> {
+    /// # fn set_reference<'b>(&mut self, reference: &'b T)
+    /// #    -> TaggedRef<'b, T, BITS> {
+    /// TaggedRef::new(reference, self.tag())
+    /// # }}
+    /// ```
+    ///
+    /// Unlike [`Self::set_reference`] this allows `self` to be dropped, so the
+    /// following compiles:
+    ///
+    /// ```
+    /// # use tagged_pointer::TaggedRef;
+    /// let (mut x, y) = (14_u32, 21_u32);
+    /// let mut tr = TaggedRef::<_, 2>::new(&x, 0);
+    /// // Drops old `tr` so `x` no longer borrowed
+    /// tr = tr.new_reference(&y);
+    /// x += 1;
+    /// let v = *tr;
+    /// ```
+    pub fn new_reference<'b>(
+        self,
+        reference: &'b T,
+    ) -> TaggedRef<'b, T, BITS> {
+        TaggedRef::new(reference, self.tag())
+    }
+
+    /// Gets the tag stored by the tagged pointer. Equivalent to
+    /// [`self.get().1`](Self::get).
+    pub fn tag(self) -> usize {
+        self.get().1
+    }
+
+    /// Sets the tag without modifying the pointer.
+    ///
+    /// This method is simply equivalent to:
+    ///
+    /// ```
+    /// # use tagged_pointer::TaggedRef;
+    /// # trait Ext { fn set_tag(&mut self, tag: usize); }
+    /// # impl<'a, T, const BITS: usize> Ext for TaggedRef<'a, T, BITS> {
+    /// # fn set_tag(&mut self, tag: usize) {
+    /// *self = Self::new(self.reference(), tag);
+    /// # }}
+    /// ```
+    pub fn set_tag(&mut self, tag: usize) {
+        *self = Self::new(self.reference(), tag);
+    }
+}
+
+impl<'a, T, const BITS: Bits> Clone for TaggedRef<'a, T, BITS> {
+    fn clone(&self) -> Self {
+        Self(self.0, self.1)
+    }
+}
+
+impl<'a, T, const BITS: Bits> Copy for TaggedRef<'a, T, BITS> {}
+
+macro_rules! derive_common {
+    ($name:ident) => {
+        impl<'a, T, const BITS: Bits> Deref for $name<'a, T, BITS> {
+            type Target = T;
+
+            fn deref(&self) -> &Self::Target {
+                self.reference()
+            }
+        }
+
+        impl<'a, T, const BITS: Bits> Borrow<T> for $name<'a, T, BITS> {
+            fn borrow(&self) -> &T {
+                self.deref()
+            }
+        }
+
+        impl<'a, T, const BITS: Bits> fmt::Pointer for $name<'a, T, BITS> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Pointer::fmt(&self.reference(), f)
+            }
+        }
+    };
+}
+
+derive_common!(TaggedRef);
+
+/// A tagged mutable reference: a space-efficient representation of a reference
+/// and integer tag.
+///
+/// This type stores an exclusive reference and an integer tag without taking
+/// up more space than a normal reference (unless the fallback implementation
+/// is used; see the [crate documentation](crate#assumptions)).
+///
+/// The tagged reference conceptually holds a `&'a mut T` and a certain number
+/// of bits of an integer tag.
+///
+/// `BITS` specifies how many bits are used for the tag. The alignment of `T`
+/// must be large enough to store this many bits; see [`Self::new`].
+#[repr(transparent)]
+pub struct TaggedMutRef<'a, T, const BITS: Bits>(
+    TaggedPtr<T, BITS>,
+    PhantomData<&'a mut T>,
+);
+
+impl<'a, T, const BITS: Bits> TaggedMutRef<'a, T, BITS> {
+    /// Creates a new tagged pointer. Only the lower `BITS` bits of `tag` are
+    /// stored.
+    ///
+    /// A check is performed at compile time to ensure that the alignment of
+    /// `T` is not less than 2<sup>`BITS`</sup> (`1 << BITS`). This ensures
+    /// that all properly aligned pointers to `T` will be aligned enough to
+    /// store the specified number of bits of the tag.
+    pub fn new(reference: &'a mut T, tag: usize) -> Self {
+        let ptr = NonNull::from(reference);
+        let tag = tag & TaggedPtr::<T, BITS>::mask();
+        // SAFETY: `reference` is guaranteed to be aligned and `tag <= mask()`.
+        let ptr = unsafe { TaggedPtr::new_unchecked(ptr, tag) };
+        Self(ptr, PhantomData)
+    }
+
+    /// Immutably gets the pointer and tag stored by the tagged pointer. If you
+    /// need both the pointer and tag, this method may be more efficient than
+    /// calling [`Self::tag`] and [`Self::reference`] separately.
+    pub fn get(&self) -> (&T, usize) {
+        // SAFETY: can only have been constructed with `TaggedMutRef::new`.
+        // Thus `ptr` will be properly aligned and “dereferenceable”.
+        let (ptr, tag) = unsafe { self.0.get_unchecked() };
+        // SAFETY: `ptr` is properly aligned and “dereferenceable”. The
+        // underlying data is initialized and immutable since we hold a shared
+        // reference to a unique `self` (`TaggedMutRef` is not duplicable)
+        // which has a `PhantomData<&'a mut T>`. We respect Rust lifetimes by
+        // returning a reference which will not live longer than the input
+        // reference (which cannot outlive `'a`) and thus prevent mutable use
+        // of `self` while the returned immutable reference is live.
+        let ptr = unsafe { ptr.as_ref() };
+        (ptr, tag)
+    }
+
+    /// Mutably gets the pointer and tag stored by the tagged pointer. If you
+    /// need both the pointer and tag, this method may be more efficient than
+    /// calling [`Self::tag`] and [`Self::reference_mut`] separately.
+    pub fn get_mut(&mut self) -> (&mut T, usize) {
+        // SAFETY: can only have been constructed with `TaggedMutRef::new`.
+        // Thus `ptr` will be properly aligned and “dereferenceable”.
+        let (mut ptr, tag) = unsafe { self.0.get_unchecked() };
+        // SAFETY: `ptr` is properly aligned and “dereferenceable”. The
+        // underlying data is initialized and unaliased since we hold a unique
+        // reference to a unique `self` (`TaggedMutRef` is not duplicable)
+        // which has a `PhantomData<&'a mut T>`. We respect Rust lifetimes by
+        // returning a reference which will not live longer than the input
+        // reference (which cannot outlive `'a`) and thus prevent any use of
+        // `self` while the returned mutable reference is live.
+        let ptr = unsafe { ptr.as_mut() };
+        (ptr, tag)
+    }
+
+    /// Deconstructs the tagged pointer to get back the arguments (pointer and
+    /// tag) passed to [`Self::new`]. If you need both the pointer and tag,
+    /// this method may be more efficient than calling [`Self::tag`] and
+    /// [`Self::reference_inner`] separately.
+    pub fn get_inner(self) -> (&'a mut T, usize) {
+        // SAFETY: can only have been constructed with `TaggedMutRef::new`.
+        // Thus `ptr` will be properly aligned and “dereferenceable”.
+        let (mut ptr, tag) = unsafe { self.0.get_unchecked() };
+        // SAFETY: `ptr` is properly aligned and “dereferenceable”. The
+        // underlying data is initialized and unaliased since we hold a unique
+        // `self` (`TaggedMutRef` is not duplicable) which has a
+        // `PhantomData<&'a mut T>`. We respect Rust lifetimes by moving out
+        // the original reference (`self` is dropped).
+        let ptr = unsafe { ptr.as_mut() };
+        (ptr, tag)
+    }
+
+    /// Immutably gets the reference stored by the tagged reference, without
+    /// the tag. Equivalent to [`self.get().0`](Self::get).
+    pub fn reference(&self) -> &T {
+        self.get().0
+    }
+
+    /// Mutably gets the reference stored by the tagged reference, without the
+    /// tag. Equivalent to [`self.get_mut().0`](Self::get_mut).
+    pub fn reference_mut(&mut self) -> &mut T {
+        self.get_mut().0
+    }
+
+    /// Gets the reference stored by the tagged reference, without the tag. The
+    /// tag is lost. Equivalent to [`self.get_inner().0`](Self::get_inner).
+    pub fn reference_inner(self) -> &'a mut T {
+        self.get_inner().0
+    }
+
+    /// Sets the reference without modifying the tag.
+    ///
+    /// This method is simply equivalent to:
+    ///
+    /// ```
+    /// # use tagged_pointer::TaggedMutRef;
+    /// # trait Ext<'a, T>
+    /// #    { fn set_reference(&mut self, reference: &'a mut T); }
+    /// # impl<'a, T, const BITS: usize> Ext<'a, T>
+    /// #    for TaggedMutRef<'a, T, BITS> {
+    /// # fn set_reference(&mut self, reference: &'a mut T) {
+    /// *self = Self::new(reference, self.tag());
+    /// # }}
+    /// ```
+    ///
+    /// Note that this method does not kill the original borrow, so the
+    /// following will not compile:
+    ///
+    /// ```compile_fail
+    /// # use tagged_pointer::TaggedMutRef;
+    /// let (mut x, mut y) = (14_u32, 21_u32);
+    /// let mut tr = TaggedMutRef::<_, 2>::new(&mut x, 0);
+    /// tr.set_reference(&mut y); // `x` stays borrowed
+    /// x += 1; // use of borrowed `x`
+    /// *tr += 1;
+    /// ```
+    ///
+    /// If you run into this issue, use [`Self::new_reference`] instead.
+    pub fn set_reference(&mut self, reference: &'a mut T) {
+        *self = Self::new(reference, self.tag());
+    }
+
+    /// Creates a new tagged reference with the same tag.
+    ///
+    /// This method is simply equivalent to:
+    ///
+    /// ```
+    /// # use tagged_pointer::TaggedMutRef;
+    /// # trait Ext<T, const BITS: usize> { fn set_reference<'b>
+    /// #    (&mut self, reference: &'b mut T) -> TaggedMutRef<'b, T, BITS>; }
+    /// # impl<'a, T, const BITS: usize> Ext<T, BITS>
+    /// #    for TaggedMutRef<'a, T, BITS> {
+    /// # fn set_reference<'b>(&mut self, reference: &'b mut T)
+    /// #    -> TaggedMutRef<'b, T, BITS> {
+    /// TaggedMutRef::new(reference, self.tag())
+    /// # }}
+    /// ```
+    ///
+    /// Unlike [`Self::set_reference`] this allows `self` to be dropped, so the
+    /// following compiles:
+    ///
+    /// ```
+    /// # use tagged_pointer::TaggedMutRef;
+    /// let (mut x, mut y) = (14_u32, 21_u32);
+    /// let mut tr = TaggedMutRef::<_, 2>::new(&mut x, 0);
+    /// // Drops old `tr` so `x` no longer borrowed
+    /// tr = tr.new_reference(&mut y);
+    /// x += 1;
+    /// *tr += 1;
+    /// ```
+    pub fn new_reference<'b>(
+        &self,
+        reference: &'b mut T,
+    ) -> TaggedMutRef<'b, T, BITS> {
+        TaggedMutRef::new(reference, self.tag())
+    }
+
+    /// Gets the tag stored by the tagged pointer. Equivalent to
+    /// [`self.get().1`](Self::get).
+    pub fn tag(&self) -> usize {
+        self.get().1
+    }
+
+    /// Sets the tag without modifying the pointer.
+    ///
+    /// This method only requires a mutable reference to `self`, while being
+    /// equivalent to the owned version:
+    ///
+    /// ```
+    /// # use tagged_pointer::TaggedMutRef;
+    /// let mut x = 14_u32;
+    /// let mut tr = TaggedMutRef::<_, 2>::new(&mut x, 0);
+    /// // The following two are equivalent:
+    /// tr.set_tag(1);
+    /// tr = TaggedMutRef::new(tr.reference_inner(), 1);
+    /// ```
+    pub fn set_tag(&mut self, tag: usize) {
+        let mut ptr = NonNull::from(self.reference_mut());
+        // SAFETY: We can extend the lifetime to `'a` since we know that this
+        // is the true lifetime of the reference `self` holds. We temporarily
+        // mutably alias through `self` and `reference` but we're about to
+        // overwrite `self` so it's ok. Beware that if `Self::new` could panic
+        // then `self` would not get overwritten, luckily this would still be
+        // ok because `reference` is immediately discarded on return.
+        let reference = unsafe { ptr.as_mut() };
+        *self = Self::new(reference, tag);
+    }
+
+    /// Creates a new identical tagged pointer. Useful to mimic the reborrow
+    /// which Rust automatically does for mutable references in various places.
+    ///
+    /// This method is simply equivalent to:
+    ///
+    /// ```
+    /// # use tagged_pointer::TaggedMutRef;
+    /// # trait Ext<T, const BITS: usize> { fn reborrow<'b>(&'b mut self)
+    /// #    -> TaggedMutRef<'b, T, BITS>; }
+    /// # impl<'a, T, const BITS: usize> Ext<T, BITS>
+    /// #    for TaggedMutRef<'a, T, BITS> {
+    /// # fn reborrow<'b>(&'b mut self) -> TaggedMutRef<'b, T, BITS> {
+    /// let (reference, tag) = self.get_mut();
+    /// TaggedMutRef::new(reference, tag)
+    /// # }}
+    /// ```
+    /// 
+    /// Use this for example when calling a function:
+    /// 
+    /// ```
+    /// # use tagged_pointer::TaggedMutRef;
+    /// fn foo<T, const BITS: usize>(tr: TaggedMutRef<T, BITS>) {
+    ///     // ...
+    /// }
+    /// let mut x = 14_u32;
+    /// let mut tr = TaggedMutRef::<_, 2>::new(&mut x, 0);
+    /// foo(tr.reborrow());
+    /// *tr += 1; // cannot use `tr` without the `reborrow` above
+    /// ```
+    pub fn reborrow<'b>(&'b mut self) -> TaggedMutRef<'b, T, BITS> {
+        let (reference, tag) = self.get_mut();
+        TaggedMutRef::new(reference, tag)
+    }
+}
+
+impl<'a, T, const BITS: Bits> DerefMut for TaggedMutRef<'a, T, BITS> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.reference_mut()
+    }
+}
+
+impl<'a, T, const BITS: Bits> BorrowMut<T> for TaggedMutRef<'a, T, BITS> {
+    fn borrow_mut(&mut self) -> &mut T {
+        self.deref_mut()
+    }
+}
+
+derive_common!(TaggedMutRef);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 taylor.fish <contact@taylor.fish>
+ * Copyright 2021-2024 taylor.fish <contact@taylor.fish>
  *
  * This file is part of tagged-pointer.
  *
@@ -41,24 +41,24 @@ fn basic() {
     #![allow(clippy::cast_possible_truncation)]
     for i in 0..64 {
         let x = i as u8 * 3;
-        let tp = TaggedPtr::<_, 0>::new((&x).into(), i);
+        let tp = TaggedPtr::new::<0>((&x).into(), i);
         assert_eq!(tp.get(), ((&x).into(), 0));
         assert_eq!(*unsafe { tp.ptr().as_ref() }, x);
 
         let x = Align2(i as u16 * 5);
-        let tp = TaggedPtr::<_, 1>::new((&x).into(), i);
+        let tp = TaggedPtr::new::<1>((&x).into(), i);
         assert_eq!(tp.get(), ((&x).into(), i & 0b1));
         assert_eq!(*unsafe { tp.ptr().as_ref() }, x);
 
         let mut x = Align4(i as u32 * 7);
         let ptr = NonNull::from(&mut x);
-        let tp = TaggedPtr::<_, 2>::new(ptr, i);
+        let tp = TaggedPtr::new::<2>(ptr, i);
         assert_eq!(tp.get(), (ptr, i & 0b11));
         unsafe { tp.ptr().as_mut() }.0 += 1;
         assert_eq!(x.0, i as u32 * 7 + 1);
 
         let x = Align8(i as u64 * 11);
-        let tp = TaggedPtr::<_, 3>::new((&x).into(), i);
+        let tp = TaggedPtr::new::<3>((&x).into(), i);
         assert_eq!(tp.get(), ((&x).into(), i & 0b111));
         assert_eq!(*unsafe { tp.ptr().as_ref() }, x);
     }
@@ -71,7 +71,7 @@ fn basic_ref() {
         let x = i as u8 * 3;
         let r = &x;
         let addr = r as *const _ as usize;
-        let tp = TaggedRef::<_, 0>::new(r, i);
+        let tp = TaggedRef::new::<0>(r, i);
         let (a, b) = tp.get();
         assert_eq!((a as *const _ as usize, b), (addr, 0));
         assert_eq!(*tp.reference(), i as u8 * 3);
@@ -79,7 +79,7 @@ fn basic_ref() {
         let x = Align2(i as u16 * 5);
         let r = &x;
         let addr = r as *const _ as usize;
-        let tp = TaggedRef::<_, 1>::new(r, i);
+        let tp = TaggedRef::new::<1>(r, i);
         let (a, b) = tp.get();
         assert_eq!((a as *const _ as usize, b), (addr, i & 0b1));
         assert_eq!(*tp.reference(), Align2(i as u16 * 5));
@@ -87,7 +87,7 @@ fn basic_ref() {
         let x = Align4(i as u32 * 7);
         let r = &x;
         let addr = r as *const _ as usize;
-        let tp = TaggedRef::<_, 2>::new(r, i);
+        let tp = TaggedRef::new::<2>(r, i);
         let (a, b) = tp.get();
         assert_eq!((a as *const _ as usize, b), (addr, i & 0b11));
         assert_eq!(*tp.reference(), Align4(i as u32 * 7));
@@ -95,7 +95,7 @@ fn basic_ref() {
         let x = Align8(i as u64 * 11);
         let r = &x;
         let addr = r as *const _ as usize;
-        let tp = TaggedRef::<_, 3>::new(r, i);
+        let tp = TaggedRef::new::<3>(r, i);
         let (a, b) = tp.get();
         assert_eq!((a as *const _ as usize, b), (addr, i & 0b111));
         assert_eq!(*tp.reference(), Align8(i as u64 * 11));
@@ -109,7 +109,7 @@ fn basic_mut_ref() {
         let mut x = i as u8 * 3;
         let r = &mut x;
         let addr = r as *const _ as usize;
-        let tp = TaggedMutRef::<_, 0>::new(r, i);
+        let tp = TaggedMutRef::new::<0>(r, i);
         let (a, b) = tp.get();
         assert_eq!((a as *const _ as usize, b), (addr, 0));
         assert_eq!(*tp.reference(), i as u8 * 3);
@@ -117,7 +117,7 @@ fn basic_mut_ref() {
         let mut x = Align2(i as u16 * 5);
         let r = &mut x;
         let addr = r as *const _ as usize;
-        let tp = TaggedMutRef::<_, 1>::new(r, i);
+        let tp = TaggedMutRef::new::<1>(r, i);
         let (a, b) = tp.get();
         assert_eq!((a as *const _ as usize, b), (addr, i & 0b1));
         assert_eq!(*tp.reference(), Align2(i as u16 * 5));
@@ -125,7 +125,7 @@ fn basic_mut_ref() {
         let mut x = Align4(i as u32 * 7);
         let r = &mut x;
         let addr = r as *const _ as usize;
-        let mut tp = TaggedMutRef::<_, 2>::new(r, i);
+        let mut tp = TaggedMutRef::new::<2>(r, i);
         let (a, b) = tp.get();
         assert_eq!((a as *const _ as usize, b), (addr, i & 0b11));
         tp.reference_mut().0 += 1;
@@ -134,7 +134,7 @@ fn basic_mut_ref() {
         let mut x = Align8(i as u64 * 11);
         let r = &mut x;
         let addr = r as *const _ as usize;
-        let tp = TaggedMutRef::<_, 3>::new(r, i);
+        let tp = TaggedMutRef::new::<3>(r, i);
         let (a, b) = tp.get();
         assert_eq!((a as *const _ as usize, b), (addr, i & 0b111));
         assert_eq!(*tp.reference(), Align8(i as u64 * 11));
@@ -146,19 +146,19 @@ fn overaligned() {
     #![allow(clippy::cast_possible_truncation)]
     for i in 0..64 {
         let x = Align2(i as u16 * 3);
-        let tp = TaggedPtr::<_, 0>::new((&x).into(), i);
-        assert_eq!(tp.get(), ((&x).into(), 0));
-        assert_eq!(*unsafe { tp.ptr().as_ref() }, x);
+        let tp = TaggedPtr::new::<0>(NonNull::from(&x).cast::<u8>(), i);
+        assert_eq!(tp.get(), (NonNull::from(&x).cast::<u8>(), 0));
+        assert_eq!(*unsafe { tp.ptr().cast::<Align2>().as_ref() }, x);
 
         let x = Align4(i as u32 * 5);
-        let tp = TaggedPtr::<_, 1>::new((&x).into(), i);
-        assert_eq!(tp.get(), ((&x).into(), i & 0b1));
-        assert_eq!(*unsafe { tp.ptr().as_ref() }, x);
+        let tp = TaggedPtr::new::<1>(NonNull::from(&x).cast::<Align2>(), i);
+        assert_eq!(tp.get(), (NonNull::from(&x).cast::<Align2>(), i & 0b1));
+        assert_eq!(*unsafe { tp.ptr().cast::<Align4>().as_ref() }, x);
 
         let x = Align8(i as u64 * 7);
-        let tp = TaggedPtr::<_, 2>::new((&x).into(), i);
-        assert_eq!(tp.get(), ((&x).into(), i & 0b11));
-        assert_eq!(*unsafe { tp.ptr().as_ref() }, x);
+        let tp = TaggedPtr::new::<2>(NonNull::from(&x).cast::<Align4>(), i);
+        assert_eq!(tp.get(), (NonNull::from(&x).cast::<Align4>(), i & 0b11));
+        assert_eq!(*unsafe { tp.ptr().cast::<Align8>().as_ref() }, x);
     }
 }
 
@@ -167,7 +167,7 @@ fn zst() {
     #![allow(clippy::let_unit_value)]
     for i in 0..8 {
         let x = ();
-        let tp = TaggedPtr::<_, 0>::new((&x).into(), i);
+        let tp = TaggedPtr::new::<0>((&x).into(), i);
         assert_eq!(tp.get(), ((&x).into(), 0));
     }
 }
@@ -179,18 +179,18 @@ fn runtime_not_aligned_enough() {
     let ptr = unsafe { (ptr as *mut u8).add(1) };
     let ptr = ptr as *mut Align2;
     let ptr = unsafe { NonNull::new_unchecked(ptr) };
-    TaggedPtr::<_, 1>::new(ptr, 0);
+    TaggedPtr::new::<1>(ptr, 0);
 }
 
 mod type_not_aligned_enough {
     /// ```
     /// use tagged_pointer::TaggedPtr;
-    /// TaggedPtr::<_, 0>::new((&0_u8).into(), 0);
+    /// TaggedPtr::new::<0>((&0_u8).into(), 0);
     /// ```
     ///
     /// ```compile_fail
     /// use tagged_pointer::TaggedPtr;
-    /// TaggedPtr::<_, 1>::new((&0_u8).into(), 0);
+    /// TaggedPtr::new::<1>((&0_u8).into(), 0);
     /// ```
     mod test1 {}
 
@@ -198,14 +198,14 @@ mod type_not_aligned_enough {
     /// use tagged_pointer::TaggedPtr;
     /// #[repr(align(2))]
     /// struct Align2(pub u16);
-    /// TaggedPtr::<_, 1>::new((&Align2(0)).into(), 0);
+    /// TaggedPtr::new::<1>((&Align2(0)).into(), 0);
     /// ```
     ///
     /// ```compile_fail
     /// use tagged_pointer::TaggedPtr;
     /// #[repr(align(2))]
     /// struct Align2(pub u16);
-    /// TaggedPtr::<_, 2>::new((&Align2(0)).into(), 0);
+    /// TaggedPtr::new::<2>((&Align2(0)).into(), 0);
     /// ```
     mod test2 {}
 
@@ -213,14 +213,14 @@ mod type_not_aligned_enough {
     /// use tagged_pointer::TaggedPtr;
     /// #[repr(align(4))]
     /// struct Align4(pub u32);
-    /// TaggedPtr::<_, 2>::new((&Align4(0)).into(), 0);
+    /// TaggedPtr::new::<2>((&Align4(0)).into(), 0);
     /// ```
     ///
     /// ```compile_fail
     /// use tagged_pointer::TaggedPtr;
     /// #[repr(align(4))]
     /// struct Align4(pub u32);
-    /// TaggedPtr::<_, 3>::new((&Align4(0)).into(), 0);
+    /// TaggedPtr::new::<3>((&Align4(0)).into(), 0);
     /// ```
     mod test3 {}
 
@@ -228,14 +228,14 @@ mod type_not_aligned_enough {
     /// use tagged_pointer::TaggedPtr;
     /// #[repr(align(8))]
     /// struct Align8(pub u64);
-    /// TaggedPtr::<_, 3>::new((&Align8(0)).into(), 0);
+    /// TaggedPtr::new::<3>((&Align8(0)).into(), 0);
     /// ```
     ///
     /// ```compile_fail
     /// use tagged_pointer::TaggedPtr;
     /// #[repr(align(8))]
     /// struct Align8(pub u64);
-    /// TaggedPtr::<_, 4>::new((&Align8(0)).into(), 0);
+    /// TaggedPtr::new::<4>((&Align8(0)).into(), 0);
     /// ```
     mod test4 {}
 }
@@ -244,7 +244,7 @@ mod type_not_aligned_enough {
 #[test]
 fn check_size() {
     assert_eq!(
-        mem::size_of::<TaggedPtr<u64, 3>>(),
+        mem::size_of::<TaggedPtr<u64>>(),
         mem::size_of::<core::ptr::NonNull<u64>>(),
     );
 }
@@ -252,25 +252,26 @@ fn check_size() {
 #[test]
 fn check_option_size() {
     assert_eq!(
-        mem::size_of::<TaggedPtr<u64, 3>>(),
-        mem::size_of::<Option<TaggedPtr<u64, 3>>>(),
+        mem::size_of::<TaggedPtr<u64>>(),
+        mem::size_of::<Option<TaggedPtr<u64>>>(),
     );
 }
 
 #[test]
 fn not_entirely_dereferenceable() {
+    #[allow(dead_code)]
     #[repr(align(8))]
     struct Type(u64, u64, u64);
 
     let a = Type(1, 2, 3);
-    let mut tp = TaggedPtr::<_, 2>::new((&a).into(), 0b10);
-    assert_eq!(tp.get(), ((&a).into(), 0b10));
+    let mut tp = TaggedPtr::new::<2>(NonNull::from(&a).cast::<Align4>(), 0b10);
+    assert_eq!(tp.get(), (NonNull::from(&a).cast::<Align4>(), 0b10));
 
     let mut b = Align4(0);
     let ptr = NonNull::from(&mut b).cast();
     tp.set_ptr(ptr);
     assert_eq!(tp.ptr(), ptr);
-    tp.set_tag(0b11);
+    tp.set_tag::<2>(0b11);
     assert_eq!(tp.tag(), 0b11);
     unsafe { tp.ptr().cast::<Align4>().as_mut() }.0 = 1234;
     assert_eq!(b.0, 1234);


### PR DESCRIPTION
> IMPORTANT: this PR is pretty much done, but is missing a big QOL improvement described below

This PR adds support for tagged references, a safe abstraction over `TaggedPtr` which is faster and never `panic`s. These are the main changes:

- Changed visibility of `PtrImpl` and corresponding methods from `pub` to `pub(crate)` to highlight that these aren't in the public interface. Happy to switch back if you don't want this.
- Added unsafe versions of `{TaggedPtr,PtrImpl}::{new,get}` as `{new,get}_unchecked` functions, these functions expose faster (no checks) versions of the safe functions.
- Implemented `TaggedRef` and `TaggedMutRef` as safe abstractions over these unchecked functions, working with `&T` and `&mut T` references respectively. `TaggedRef` implements `Copy` (and `Clone`), while `TaggedMutRef` implements `DerefMut`. The both implement `Deref`.
- Added some initial tests

Things still left to do (other than fixing any cosmetic issues):

- [x] Remove the need for a `const BITS: Bits` parameter on both `TaggedRef` and `TaggedMutRef`, instead always use `mem::align_of::<T>().trailing_zeros()`. This would be a huge QOL improvement since any function which wants to take such refs as an argument doesn't need to explicitly pick some `BITS` value.
- [x] Decide on `TaggedMutRef` vs `TaggedRefMut` as a name
- [ ] Add more tests once the design finalised